### PR TITLE
Removed in-place operation

### DIFF
--- a/lucent/optvis/param/spatial.py
+++ b/lucent/optvis/param/spatial.py
@@ -38,6 +38,6 @@ def fft_image(shape, sd=None, decay_power=1):
         image = torch.irfft(scaled_spectrum_t, 2, normalized=True, signal_sizes=(h, w))
         image = image[:batch, :channels, :h, :w]
         magic = 4.0 # Magic constant from Lucid library; increasing this seems to reduce saturation
-        image /= magic
+        image = image / magic
         return image
     return [spectrum_real_imag_t], inner


### PR DESCRIPTION
In-place operations are generally slower, often end up requiring more memory, and can interfere with Autograd. Thus, they should always be avoided unless you have an edge case that requires them.

https://pytorch.org/docs/stable/notes/autograd.html#in-place-operations-with-autograd


Lucid also doesn't do an in-place operation either: https://github.com/tensorflow/lucid/blob/master/lucid/optvis/param/spatial.py#L86