### PR TITLE
Add activation grids notebook

### DIFF
--- a/lucent/misc/channel_reducer.py
+++ b/lucent/misc/channel_reducer.py
@@ -1,0 +1,117 @@
+# Copyright 2018 The Lucid Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Helper for using sklearn.decomposition on high-dimensional tensors.
+
+Provides ChannelReducer, a wrapper around sklearn.decomposition to help them
+apply to arbitrary rank tensors. It saves lots of annoying reshaping.
+"""
+
+import numpy as np
+import sklearn.decomposition
+
+try:
+    from sklearn.decomposition.base import BaseEstimator
+except AttributeError:
+    from sklearn.base import BaseEstimator
+
+
+class ChannelReducer(object):
+  """Helper for dimensionality reduction to the innermost dimension of a tensor.
+
+  This class wraps sklearn.decomposition classes to help them apply to arbitrary
+  rank tensors. It saves lots of annoying reshaping.
+
+  See the original sklearn.decomposition documentation:
+  http://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition
+  """
+
+  def __init__(self, n_components=3, reduction_alg="NMF", **kwargs):
+    """Constructor for ChannelReducer.
+
+    Inputs:
+      n_components: Numer of dimensions to reduce inner most dimension to.
+      reduction_alg: A string or sklearn.decomposition class. Defaults to
+        "NMF" (non-negative matrix facotrization). Other options include:
+        "PCA", "FastICA", and "MiniBatchDictionaryLearning". The name of any of
+        the sklearn.decomposition classes will work, though.
+      kwargs: Additional kwargs to be passed on to the reducer.
+    """
+
+    if not isinstance(n_components, int):
+      raise ValueError("n_components must be an int, not '%s'." % n_components)
+
+    # Defensively look up reduction_alg if it is a string and give useful errors.
+    algorithm_map = {}
+    for name in dir(sklearn.decomposition):
+      obj = sklearn.decomposition.__getattribute__(name)
+      if isinstance(obj, type) and issubclass(obj, BaseEstimator):
+        algorithm_map[name] = obj
+    if isinstance(reduction_alg, str):
+      if reduction_alg in algorithm_map:
+        reduction_alg = algorithm_map[reduction_alg]
+      else:
+        raise ValueError("Unknown dimensionality reduction method '%s'." % reduction_alg)
+
+
+    self.n_components = n_components
+    self._reducer = reduction_alg(n_components=n_components, **kwargs)
+    self._is_fit = False
+
+  @classmethod
+  def _apply_flat(cls, f, acts):
+    """Utility for applying f to inner dimension of acts.
+
+    Flattens acts into a 2D tensor, applies f, then unflattens so that all
+    dimesnions except innermost are unchanged.
+    """
+    orig_shape = acts.shape
+    acts_flat = acts.reshape([-1, acts.shape[-1]])
+    new_flat = f(acts_flat)
+    if not isinstance(new_flat, np.ndarray):
+      return new_flat
+    shape = list(orig_shape[:-1]) + [-1]
+    return new_flat.reshape(shape)
+
+  def fit(self, acts):
+    self._is_fit = True
+    return ChannelReducer._apply_flat(self._reducer.fit, acts)
+
+  def fit_transform(self, acts):
+    self._is_fit = True
+    return ChannelReducer._apply_flat(self._reducer.fit_transform, acts)
+
+  def transform(self, acts):
+    return ChannelReducer._apply_flat(self._reducer.transform, acts)
+
+  def __call__(self, acts):
+    if self._is_fit:
+      return self.transform(acts)
+    else:
+      return self.fit_transform(acts)
+
+  def __getattr__(self, name):
+    if name in self.__dict__:
+      return self.__dict__[name]
+    elif name + "_" in self._reducer.__dict__:
+      return self._reducer.__dict__[name+"_"]
+
+  def __dir__(self):
+    dynamic_attrs = [name[:-1]
+                     for name in dir(self._reducer)
+                     if name[-1] == "_" and name[0] != "_"
+                    ]
+
+    return list(ChannelReducer.__dict__.keys()) + list(self.__dict__.keys()) + dynamic_attrs

--- a/lucent/misc/channel_reducer.py
+++ b/lucent/misc/channel_reducer.py
@@ -29,7 +29,7 @@ except AttributeError:
 
 
 class ChannelReducer(object):
-  """Helper for dimensionality reduction to the innermost dimension of a tensor.
+    """Helper for dimensionality reduction to the innermost dimension of a tensor.
 
   This class wraps sklearn.decomposition classes to help them apply to arbitrary
   rank tensors. It saves lots of annoying reshaping.
@@ -38,80 +38,88 @@ class ChannelReducer(object):
   http://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition
   """
 
-  def __init__(self, n_components=3, reduction_alg="NMF", **kwargs):
-    """Constructor for ChannelReducer.
+    def __init__(self, n_components=3, reduction_alg="NMF", **kwargs):
+        """
+        Constructor for ChannelReducer.
 
-    Inputs:
-      n_components: Numer of dimensions to reduce inner most dimension to.
-      reduction_alg: A string or sklearn.decomposition class. Defaults to
-        "NMF" (non-negative matrix facotrization). Other options include:
-        "PCA", "FastICA", and "MiniBatchDictionaryLearning". The name of any of
-        the sklearn.decomposition classes will work, though.
-      kwargs: Additional kwargs to be passed on to the reducer.
-    """
+        Inputs:
+          n_components: Number of dimensions to reduce inner most dimension to.
+          reduction_alg: A string or sklearn.decomposition class. Defaults to
+            "NMF" (non-negative matrix facotrization). Other options include:
+            "PCA", "FastICA", and "MiniBatchDictionaryLearning". The name of any of
+            the sklearn.decomposition classes will work, though.
+          kwargs: Additional kwargs to be passed on to the reducer.
+        """
 
-    if not isinstance(n_components, int):
-      raise ValueError("n_components must be an int, not '%s'." % n_components)
+        if not isinstance(n_components, int):
+            raise ValueError("n_components must be an int, not '%s'." % n_components)
+        if n_components <= 0:
+            raise ValueError("n_components must be strictly > 0")
+        # Defensively look up reduction_alg if it is a string and give useful errors.
+        algorithm_map = {}
+        for name in dir(sklearn.decomposition):
+            obj = sklearn.decomposition.__getattribute__(name)
+            if isinstance(obj, type) and issubclass(obj, BaseEstimator):
+                algorithm_map[name] = obj
+        if isinstance(reduction_alg, str):
+            if reduction_alg in algorithm_map:
+                reduction_alg = algorithm_map[reduction_alg]
+            else:
+                raise ValueError(
+                    "Unknown dimensionality reduction method '%s'." % reduction_alg
+                )
 
-    # Defensively look up reduction_alg if it is a string and give useful errors.
-    algorithm_map = {}
-    for name in dir(sklearn.decomposition):
-      obj = sklearn.decomposition.__getattribute__(name)
-      if isinstance(obj, type) and issubclass(obj, BaseEstimator):
-        algorithm_map[name] = obj
-    if isinstance(reduction_alg, str):
-      if reduction_alg in algorithm_map:
-        reduction_alg = algorithm_map[reduction_alg]
-      else:
-        raise ValueError("Unknown dimensionality reduction method '%s'." % reduction_alg)
+        self.n_components = n_components
+        self._reducer = reduction_alg(n_components=n_components, **kwargs)
+        self._is_fit = False
 
+    @classmethod
+    def _apply_flat(cls, f, acts):
+        """
+        Utility for applying f to inner dimension of acts.
+        Flattens acts into a 2D tensor, applies f, then unflattens so that all
+        dimesnions except innermost are unchanged.
+        """
+        orig_shape = acts.shape
+        acts_flat = acts.reshape([-1, acts.shape[-1]])
+        new_flat = f(acts_flat)
+        if not isinstance(new_flat, np.ndarray):
+            return new_flat
+        shape = list(orig_shape[:-1]) + [-1]
+        return new_flat.reshape(shape)
 
-    self.n_components = n_components
-    self._reducer = reduction_alg(n_components=n_components, **kwargs)
-    self._is_fit = False
+    def fit(self, acts):
+        self._is_fit = True
+        return ChannelReducer._apply_flat(self._reducer.fit, acts)
 
-  @classmethod
-  def _apply_flat(cls, f, acts):
-    """Utility for applying f to inner dimension of acts.
+    def fit_transform(self, acts):
+        self._is_fit = True
+        return ChannelReducer._apply_flat(self._reducer.fit_transform, acts)
 
-    Flattens acts into a 2D tensor, applies f, then unflattens so that all
-    dimesnions except innermost are unchanged.
-    """
-    orig_shape = acts.shape
-    acts_flat = acts.reshape([-1, acts.shape[-1]])
-    new_flat = f(acts_flat)
-    if not isinstance(new_flat, np.ndarray):
-      return new_flat
-    shape = list(orig_shape[:-1]) + [-1]
-    return new_flat.reshape(shape)
+    def transform(self, acts):
+        return ChannelReducer._apply_flat(self._reducer.transform, acts)
 
-  def fit(self, acts):
-    self._is_fit = True
-    return ChannelReducer._apply_flat(self._reducer.fit, acts)
+    def __call__(self, acts):
+        if self._is_fit:
+            return self.transform(acts)
+        else:
+            return self.fit_transform(acts)
 
-  def fit_transform(self, acts):
-    self._is_fit = True
-    return ChannelReducer._apply_flat(self._reducer.fit_transform, acts)
+    def __getattr__(self, name):
+        if name in self.__dict__:
+            return self.__dict__[name]
+        elif name + "_" in self._reducer.__dict__:
+            return self._reducer.__dict__[name + "_"]
 
-  def transform(self, acts):
-    return ChannelReducer._apply_flat(self._reducer.transform, acts)
+    def __dir__(self):
+        dynamic_attrs = [
+            name[:-1]
+            for name in dir(self._reducer)
+            if name[-1] == "_" and name[0] != "_"
+        ]
 
-  def __call__(self, acts):
-    if self._is_fit:
-      return self.transform(acts)
-    else:
-      return self.fit_transform(acts)
-
-  def __getattr__(self, name):
-    if name in self.__dict__:
-      return self.__dict__[name]
-    elif name + "_" in self._reducer.__dict__:
-      return self._reducer.__dict__[name+"_"]
-
-  def __dir__(self):
-    dynamic_attrs = [name[:-1]
-                     for name in dir(self._reducer)
-                     if name[-1] == "_" and name[0] != "_"
-                    ]
-
-    return list(ChannelReducer.__dict__.keys()) + list(self.__dict__.keys()) + dynamic_attrs
+        return (
+            list(ChannelReducer.__dict__.keys())
+            + list(self.__dict__.keys())
+            + dynamic_attrs
+        )

--- a/lucent/optvis/render.py
+++ b/lucent/optvis/render.py
@@ -68,7 +68,7 @@ def render_vis(
     image_shape = image_f().shape
     if fixed_image_size is not None:
         new_size = fixed_image_size
-    elif image_shape[2] < 224 or min_image_size[3] < 224:
+    elif image_shape[2] < 224 or image_shape[3] < 224:
         new_size = 224
     else:
         new_size = None

--- a/lucent/optvis/render.py
+++ b/lucent/optvis/render.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
 from collections import OrderedDict
 import numpy as np
 from tqdm import tqdm
@@ -94,13 +95,15 @@ def render_vis(
                 model(transform_f(image_f()))
             except RuntimeError as ex:
                 if i == 1:
-                    print(
+                    # Only display the warning message
+                    # on the first iteration, no need to do that
+                    # every iteration
+                    warnings.warn(
                         "Some layers could not be computed because the size of the "
                         "image is not big enough. It is fine, as long as the non"
                         "computed layers are not used in the objective function"
+                        f"(exception details: '{ex}')"
                     )
-                    print("Details:")
-                    print(ex)
             loss = objective_f(hook)
             loss.backward()
             optimizer.step()

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "pytest-mock",
         "coverage",
         "coveralls",
+        "scikit-learn"
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/tests/misc/test_channel_reducer.py
+++ b/tests/misc/test_channel_reducer.py
@@ -1,0 +1,116 @@
+# Copyright 2020 The Lucent Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import pytest
+
+import numpy as np
+from lucent.misc.channel_reducer import ChannelReducer
+
+
+def test_reduction_alg_name():
+    with pytest.raises(ValueError):
+        channel = ChannelReducer(reduction_alg="wrong")
+    names = ["NMF", "PCA", "FastICA"]
+    for name in names:
+        channel = ChannelReducer(reduction_alg=name)
+
+
+def test_n_components():
+    with pytest.raises(ValueError):
+        channel = ChannelReducer(n_components=None)
+    with pytest.raises(ValueError):
+        channel = ChannelReducer(n_components="string")
+    with pytest.raises(ValueError):
+        channel = ChannelReducer(n_components=0)
+    channel = ChannelReducer(n_components=1)
+    channel = ChannelReducer(n_components=3)
+
+
+def test_fit_and_transform():
+    nb_examples = 4
+    height = 8
+    width = 8
+    feature_maps = 16
+    n_components = 5
+    np.random.seed(42)
+    acts = np.random.uniform(size=(nb_examples, height, width, feature_maps))
+
+    # fit then transform
+    channel_reducer = ChannelReducer(n_components=n_components)
+    channel_reducer.fit(acts)
+    assert channel_reducer._is_fit
+    assert channel_reducer.transform(acts).shape == (
+        nb_examples,
+        height,
+        width,
+        n_components,
+    )
+    # fit_transform
+    channel_reducer = ChannelReducer(n_components=n_components)
+    assert channel_reducer.fit_transform(acts).shape == (
+        nb_examples,
+        height,
+        width,
+        n_components,
+    )
+
+    # wrong shape for transform
+    channel_reducer = ChannelReducer(n_components=n_components)
+    channel_reducer.fit(acts)
+    with pytest.raises(ValueError):
+        acts_ = np.random.uniform(size=(nb_examples, height, width, 5))
+        channel_reducer.transform(acts_)
+    with pytest.raises(ValueError):
+        acts_ = np.random.uniform(size=(nb_examples, height, width))
+        channel_reducer.transform(acts_)
+
+    # equivalence between fit_transform and fit then transform
+    channel_reducer = ChannelReducer(n_components=n_components)
+    y1 = channel_reducer.fit_transform(acts)
+    channel_reducer = ChannelReducer(n_components=n_components)
+    channel_reducer.fit(acts)
+    y2 = channel_reducer.transform(acts)
+    assert np.allclose(y1, y2, atol=1e-2)
+
+
+def test_call():
+    nb_examples = 4
+    height = 8
+    width = 8
+    feature_maps = 16
+    n_components = 5
+    np.random.seed(42)
+    acts = np.random.uniform(size=(nb_examples, height, width, feature_maps))
+
+    channel_reducer = ChannelReducer(n_components=n_components)
+    channel_reducer.fit(acts)
+    y = channel_reducer(acts)
+    assert np.allclose(y, channel_reducer.transform(acts), atol=1e-2)
+
+    channel_reducer = ChannelReducer(n_components=n_components)
+    y = channel_reducer(acts)
+    assert np.allclose(y, channel_reducer.transform(acts), atol=1e-2)
+
+
+def test_get_attr():
+    nb_examples = 4
+    height = 8
+    width = 8
+    feature_maps = 16
+    n_components = 5
+    np.random.seed(42)
+    acts = np.random.uniform(size=(nb_examples, height, width, feature_maps))
+    channel_reducer = ChannelReducer(n_components=n_components)
+    channel_reducer.fit(acts)
+    assert channel_reducer.components.shape == (n_components, feature_maps)


### PR DESCRIPTION
Issue #3, reproducing activation grids (https://github.com/tensorflow/lucid/blob/master/notebooks/building-blocks/ActivationGrid.ipynb)

It's possible to try it here: https://colab.research.google.com/drive/1pEe-KmXeDJcWQYLOHwcMubS69wVVCHLe#scrollTo=xidm-QrXvL2X

Here are the results so far with inceptionv1 and layer mixed4d:
- reproduced: https://imgur.com/twmizR4
- original:  https://imgur.com/eaYwEWR

Some remarks and a question:

- I added channel_reducer as is from the original repo
- default transforms in transform.py produce a different size (due to random scaling) each time it is called, then resampling to 224 is done after that to have a fixed size. Is that the same in lucid? I need to debug a little bit in the original repo to be sure to answer that, but please let me know if you have the answer. The reason I ask is that in this specific notebook, the cells in the grid  are much smaller than 224. I added an argument "fixed_image_size" to handle this specific case where we want a fixed image size (after resampling) which is not 224.
- Since all layers are computed and with this commit we can accept smaller images, this means that it's possible to have an exception on higher layers because the image size is not big enough, but it should be fine as long as the layer we are interested in is computed, I handled this exception
