### PR TITLE
Fixing render_vis side effect on transforms

### DIFF
--- a/lucent/optvis/render.py
+++ b/lucent/optvis/render.py
@@ -54,7 +54,8 @@ def render_vis(
     optimizer = optimizer(params)
 
     if transforms is None:
-        transforms = transform.standard_transforms.copy()
+        transforms = transform.standard_transforms
+    transforms = transforms.copy()
 
     if preprocess:
         if model._get_name() == "InceptionV1":


### PR DESCRIPTION
SUMMARY:
The render.render_vis function used to append to the transforms list
passed to it. You can see it for the example in the tutorial.ipynb
notebook by inspecting the all_transforms list - it got added
preprocess_inceptionv1 and Upscale for each time it was used. As a
result if you run a cell couple of times it would eventually stop
working.

TEST PLAN:
Tested with passing both a custom array of transforms and
None. Validated that the code works and neither custom array nor
transform.standard_transforms gets modified.