### PR TITLE
Switch to correct irfft for 1.8.0

### DIFF
--- a/lucent/optvis/param/spatial.py
+++ b/lucent/optvis/param/spatial.py
@@ -54,7 +54,7 @@ def fft_image(shape, sd=None, decay_power=1):
 
     def inner():
         scaled_spectrum_t = scale * spectrum_real_imag_t
-        image = torch.irfft(scaled_spectrum_t, 2, normalized=True, signal_sizes=(h, w))
+        image = torch.fft.irfft(scaled_spectrum_t, 2, normalized=True, signal_sizes=(h, w))
         image = image[:batch, :channels, :h, :w]
         magic = 4.0 # Magic constant from Lucid library; increasing this seems to reduce saturation
         image = image / magic

--- a/lucent/optvis/param/spatial.py
+++ b/lucent/optvis/param/spatial.py
@@ -54,7 +54,7 @@ def fft_image(shape, sd=None, decay_power=1):
 
     def inner():
         scaled_spectrum_t = scale * spectrum_real_imag_t
-        image = torch.fft.irfft(scaled_spectrum_t, 2, normalized=True, signal_sizes=(h, w))
+        image = torch.fft.irfft(scaled_spectrum_t, 2, norm="backward")
         image = image[:batch, :channels, :h, :w]
         magic = 4.0 # Magic constant from Lucid library; increasing this seems to reduce saturation
         image = image / magic


### PR DESCRIPTION
torch.irfft was deprecated in 1.8.0 in deference to torch.fft.irfft