### PR TITLE
Convert numpy.int64 to python native int in 'random_scale'

### DIFF
--- a/lucent/optvis/transform.py
+++ b/lucent/optvis/transform.py
@@ -52,7 +52,7 @@ def random_scale(scales):
     def inner(image_t):
         scale = np.random.choice(scales)
         shp = image_t.shape[2:]
-        scale_shape = [_roundup(scale * d) for d in shp]
+        scale_shape = [int(_roundup(scale * d)) for d in shp]
         pad_x = max(0, _roundup((shp[1] - scale_shape[1]) / 2))
         pad_y = max(0, _roundup((shp[0] - scale_shape[0]) / 2))
         upsample = torch.nn.Upsample(


### PR DESCRIPTION
This pull request addresses a TypeError triggered by the random_scale function in transform.py

<img width="1084" alt="TypeError" src="https://github.com/greentfrapp/lucent/assets/34586439/c9cfae85-06ce-4225-beb4-9f756ef46a74">

The error is encountered when running certain Colab notebooks based on lucent ( (eg:[neuron_interaction](https://github.com/greentfrapp/lucent-notebooks/blob/master/notebooks/neuron_interaction.ipynb)) with PyTorch 2.1.

The issue is resolved by converting the scale_shape local variable from a list of numpy.int64 to native Python int, ensuring compatibility with nn.Upsample.





